### PR TITLE
chore: rename bundle to experience-sdk.global.js

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,14 +4,15 @@
   "description": "A lightweight, explainable client-side experience runtime",
   "private": false,
   "type": "module",
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/experience-sdk.js",
+  "module": "./dist/experience-sdk.js",
+  "types": "./dist/experience-sdk.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
-    }
+      "types": "./dist/experience-sdk.d.ts",
+      "import": "./dist/experience-sdk.js"
+    },
+    "./dist/experience-sdk.global.js": "./dist/experience-sdk.global.js"
   },
   "files": [
     "dist"

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => ({
-  entry: ['src/index.ts'],
+  entry: {
+    'experience-sdk': 'src/index.ts',
+  },
   // Only build ESM in watch mode (faster, no bundling issues)
   // Build both ESM and IIFE in production
   format: options.watch ? ['esm'] : ['esm', 'iife'],


### PR DESCRIPTION
- Rename IIFE bundle from index.global.js to experience-sdk.global.js
- Rename ESM output from index.js to experience-sdk.js
- Update package.json exports to match new filenames
- Better naming for CDN usage (unpkg/jsdelivr)