### PR TITLE
feat(banner): add pushDown option to push content down

### DIFF
--- a/.changeset/feat-banner-pushdown.md
+++ b/.changeset/feat-banner-pushdown.md
@@ -1,0 +1,24 @@
+---
+'@prosdevlab/experience-sdk-plugins': patch
+---
+
+feat(banner): add pushDown option to push content down instead of overlay
+
+Add optional `pushDown` config to banner plugin that allows top banners to smoothly push page content down (add margin-top) instead of overlaying it.
+
+**Usage:**
+```typescript
+init({
+  banner: {
+    position: 'top',
+    pushDown: 'header' // CSS selector of element to push down
+  }
+});
+```
+
+**Benefits:**
+- Opt-in feature (default behavior unchanged)
+- Smooth transition with CSS animations
+- Improves UX for sticky navigation
+- Automatically removes margin when banner is dismissed
+


### PR DESCRIPTION
## Summary

Add optional `pushDown` config to banner plugin that allows top banners to smoothly push page content down (add margin-top) instead of overlaying it.

## Changes

- Add `pushDown?: string` to `BannerPluginConfig`
- Implement `applyPushDown()` and `removePushDown()` helper functions
- Apply margin-top to target element when top banner is shown
- Remove margin-top when banner is dismissed
- Update JSDoc with usage examples

## Usage

```typescript
init({
  banner: {
    position: 'top',
    pushDown: 'header' // CSS selector of element to push down
  }
});
```

## Benefits

- [x] Opt-in feature (default behavior unchanged)
- [x] Smooth transition with CSS animations
- [x] Improves UX for sticky navigation
- [x] Automatically removes margin when banner is dismissed
- [x] Backward compatible

## Testing

- Manually tested with various selectors
- Works with sticky navigation headers
- Gracefully handles invalid selectors